### PR TITLE
Add "deploy to Heroku" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ To install this add-on to an existing Heroku app, run the following:
 heroku addons:create sudo-sandwich
 ```
 
+To test the app yourself, you can deploy it using this button:
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ## Add-on manifest
 
 ### Heroku docs

--- a/app.json
+++ b/app.json
@@ -1,0 +1,47 @@
+{
+  "name": "Sudo Sandwich",
+  "description": "Example Heroku add-on built with Rails.",
+  "repository": "https://github.com/heroku/sudo-sandwich",
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "free"
+    },
+    "worker": {
+      "quantity": 1,
+      "size": "free"
+    }
+  },
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    }
+  ],
+  "env": {
+    "SLUG":{
+      "description": "Slug for add-on. Must match 'id' value in addon-manifest.json",
+      "required": true
+    },
+    "PASSWORD":{
+      "description": "Password for basic auth. Must match 'password' value in addon-manifest.json",
+      "required": true
+    },
+    "ENCRYPTION_KEY":{
+      "description": "Encryption key for attr_encrypted attributes",
+      "required": true,
+      "generator": "secret"
+    },
+    "SSO_SALT":{
+      "description": "Salt for SSO. Must match 'sso_salt' value in addon-manifest.json",
+      "required": true
+    }
+  },
+  "addons": [
+    {
+      "plan": "heroku-postgresql",
+      "options": {
+        "version": "9.5"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This may require more instruction later. Eg: someone needs to set up an add-on with Heroku (generate and submit addon-manifest.json) before it will really work to deploy the add-on to Heroku and start using it.