### PR TITLE
Rework the async provisioning flow to match best practices

### DIFF
--- a/app/controllers/heroku/resources_controller.rb
+++ b/app/controllers/heroku/resources_controller.rb
@@ -5,6 +5,11 @@ module Heroku
         message = 'Thanks for using Sudo Sandwich. Your add-on is available for use immediately!'
         status = 200
         state = 'provisioned'
+        payload = {
+          config: {
+            SUDO_SANDWICH_COMMAND: Sandwich::PLAN_CONFIG[plan],
+          }
+        }
       else # async provisioning
         message = 'Sudo Sandwich is being provisioned. It will be available shortly.'
         status = 202
@@ -17,11 +22,8 @@ module Heroku
       render(
         json: {
           id: heroku_uuid,
-          config: {
-            SUDO_SANDWICH_COMMAND: Sandwich::PLAN_CONFIG[plan],
-          },
           message: message
-        },
+        }.merge(payload || {}),
         status: status
       )
     end

--- a/app/jobs/provision_plan_job.rb
+++ b/app/jobs/provision_plan_job.rb
@@ -2,6 +2,6 @@ class ProvisionPlanJob < ApplicationJob
   queue_as :default
 
   def perform(sandwich_id:)
-    PlanProvisioner.new(sandwich_id: sandwich_id).run
+    AsyncPlanProvisioner.new(sandwich_id: sandwich_id).run
   end
 end

--- a/app/services/async_plan_provisioner.rb
+++ b/app/services/async_plan_provisioner.rb
@@ -1,4 +1,4 @@
-class PlanProvisioner
+class AsyncPlanProvisioner
   BASE_URL = 'https://api.heroku.com'
 
   def initialize(sandwich_id:)

--- a/app/services/plan_provisioner.rb
+++ b/app/services/plan_provisioner.rb
@@ -10,7 +10,7 @@ class PlanProvisioner
       AccessTokenRefresher.new(sandwich_id: sandwich_id).run
     end
 
-    set_config_variable
+    update_config_variable
     mark_addon_as_provisioned
     sandwich.update(state: 'provisioned')
   end
@@ -19,7 +19,7 @@ class PlanProvisioner
 
   attr_reader :sandwich_id
 
-  def set_config_variable
+  def update_config_variable
     Excon.new(BASE_URL).patch(
       path: "/addons/#{heroku_uuid}/config",
       headers: {

--- a/app/services/plan_provisioner.rb
+++ b/app/services/plan_provisioner.rb
@@ -20,8 +20,8 @@ class PlanProvisioner
   attr_reader :sandwich_id
 
   def set_config_variable
-    Excon.new(BASE_URL).post(
-      path: "/addons/#{heroku_uuid}/actions/provision",
+    Excon.new(BASE_URL).patch(
+      path: "/addons/#{heroku_uuid}/config",
       headers: {
         'Accept' => 'application/vnd.heroku+json; version=3',
         'Authorization' => "Bearer #{access_token}",

--- a/spec/controllers/heroku/resources_controller_spec.rb
+++ b/spec/controllers/heroku/resources_controller_spec.rb
@@ -106,9 +106,6 @@ RSpec.describe Heroku::ResourcesController do
         heroku_uuid = '123-ABC-456-DEF'
         expected_response = {
           id: heroku_uuid,
-          config: {
-            SUDO_SANDWICH_COMMAND: 'Make me a PB&J!'
-          },
           message: 'Sudo Sandwich is being provisioned. It will be available shortly.'
         }
 

--- a/spec/jobs/provision_plan_job_spec.rb
+++ b/spec/jobs/provision_plan_job_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe ProvisionPlanJob do
     it 'calls the provision plan class' do
       sandwich = double(id: 123)
       provisioner_double = double(run: true)
-      allow(PlanProvisioner).to receive(:new).and_return(provisioner_double)
+      allow(AsyncPlanProvisioner).to receive(:new).and_return(provisioner_double)
 
       ProvisionPlanJob.perform_now(sandwich_id: sandwich.id)
 
-      expect(PlanProvisioner).to have_received(:new).with(
+      expect(AsyncPlanProvisioner).to have_received(:new).with(
         sandwich_id: sandwich.id,
       )
       expect(provisioner_double).to have_received(:run)

--- a/spec/services/async_plan_provisioner_spec.rb
+++ b/spec/services/async_plan_provisioner_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe PlanProvisioner do
+RSpec.describe AsyncPlanProvisioner do
   describe '#run' do
     it 'updates the state to provisioned' do
       heroku_uuid = 'some-uuid'
@@ -10,7 +10,7 @@ RSpec.describe PlanProvisioner do
         access_token_expires_at: Time.now.utc + 1.day,
       )
 
-      PlanProvisioner.new(sandwich_id: sandwich.id).run
+      described_class.new(sandwich_id: sandwich.id).run
 
       expect(sandwich.reload.state).to eq 'provisioned'
     end
@@ -29,7 +29,7 @@ RSpec.describe PlanProvisioner do
           refresher_double = double(run: true)
           allow(AccessTokenRefresher).to receive(:new).and_return(refresher_double)
 
-          PlanProvisioner.new(sandwich_id: sandwich.id).run
+          described_class.new(sandwich_id: sandwich.id).run
 
           expect(AccessTokenRefresher).to have_received(:new).with(
             sandwich_id: sandwich.id,
@@ -51,7 +51,7 @@ RSpec.describe PlanProvisioner do
           )
           allow(AccessTokenRefresher).to receive(:new)
 
-          PlanProvisioner.new(sandwich_id: sandwich.id).run
+          described_class.new(sandwich_id: sandwich.id).run
 
           expect(AccessTokenRefresher).not_to have_received(:new)
         end


### PR DESCRIPTION
Includes:

* Don't set config during initial async provisioning response
* Update config for async add-ons
* PlanProvisioner -> AsyncPlanProvisioner
* Update README