### PR TITLE
Send usage data to Addons.h.c

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ In order to test this against staging, the following data must first exist in
   an `effective_at` datetime attribute that is older than the beginning of the
   previous hour.
 - An `AddonResource` for the `Addon`.
-- An `AddonResource` plan for the `AddonResource` and `Plan`. Must have an
+- An `AddonResourcePlan` for the `AddonResource` and `Plan`. Must have an
   `effective_at` datetime attribute that is older than the beginning of the
   previous hour.
 

--- a/README.md
+++ b/README.md
@@ -256,14 +256,17 @@ In order to test this against staging, the following data must first exist in
 `addons-staging.heroku.com`:
 
 - An `Addon` with a slug that matches the slug sent in the
-  `/api/v3/addons/#{slug}/usage_batches` endpoint
-- An `AddonResource` for the `Addon`.
-  `resource['id']` sent in the test request's JSON request body.
+  `/api/v3/addons/#{slug}/usage_batches` endpoint (currently hard-coded to
+`sudo-sandwich` in the service class).
 - A `Plan` record that belongs to the `Addon` and has the `usage` attribute set
   to true.
 - A `Unit` record belongs to the `Addon`.
 - A `Pricing` record for the `Plan` and `Unit` above. The `Pricing` must have
   an `effective_at` datetime attribute that is older than the beginning of the
+  previous hour.
+- An `AddonResource` for the `Addon`.
+- An `AddonResource` plan for the `AddonResource` and `Plan`. Must have an
+  `effective_at` datetime attribute that is older than the beginning of the
   previous hour.
 
 In order to test this against staging, the following data must first exist in

--- a/README.md
+++ b/README.md
@@ -238,3 +238,74 @@ redirected to the
 [`Heroku::DashboardController#show`](app/controllers/heroku/dashboard_controller.rb)
 action. In this view, the end user can see information about their add-on
 resource. This is where you'd build your add-on resource dashboard.
+
+## Usage reporting
+
+This is a feature that is under active development (pre-alpha).
+
+The `ReportUsageJob` calls the `UsageReporter` service class, which sends usage
+data to `https://addons-staging.herokuapp.com`. The data is sent to the
+`/api/v3/addons/#{slug}/usage_batches` endpoint in the add-ons staging instance.
+Basic authentication credentials are sent via the headers. The username and
+password must match the Manifest credentials for the `Addon` for which usage
+data is being reported. See [the
+docs](https://devcenter.heroku.com/articles/building-an-add-on#basic-authentication)
+for more info on basic auth.
+
+In order to test this against staging, the following data must first exist in
+`addons-staging.heroku.com`:
+
+- An `Addon` with a slug that matches the slug sent in the
+  `/api/v3/addons/#{slug}/usage_batches` endpoint
+- An `AddonResource` for the `Addon`.
+  `resource['id']` sent in the test request's JSON request body.
+- A `Plan` record that belongs to the `Addon` and has the `usage` attribute set
+  to true.
+- A `Unit` record belongs to the `Addon`.
+- A `Pricing` record for the `Plan` and `Unit` above. The `Pricing` must have
+  an `effective_at` datetime attribute that is older than the beginning of the
+  previous hour.
+
+In order to test this against staging, the following data must first exist in
+the Sudo Sandwich database from which you are testing:
+
+- A `Sandwich` record the a `heroku_uuid` attribute that matches the
+  `AddonResource#uuid` above.
+- A `Usage` record that belongs to the `Sandwich` record, and a timestamp that
+  is equal to the hour boundary of the previous hour (in Ruby,
+  `DateTime.now.beginning_of_hour - 1.hour`), and a `unit` attribute that is
+  equal to the `Unit#name` above.
+
+The JSON body sent with the request to the usage endpoint contains a `timestamp`
+and an array of `usages`. The timestamp, which represents the datetime that
+the usage data s being reporting for, must be in `YYYY-MM-DDThh:mm:ssZ` format
+and must be hour boundary of previous hour (cannot be for further in past or for
+future).
+
+The `usages` array contains usage records. Each record must contain the
+`quantity`, `uuid` of the associated `AddonResource`, and `Unit#name`. The JSON is
+formatted as follows:
+
+```
+{
+ "timestamp": "2018-07-11T03:00:00Z"
+  "usages": [
+    {
+      "quantity": 5,
+      "resource": {"id": "addon-resource-uuid"},
+      "unit": {"name": "nibbles"},
+    }
+  ]
+}
+```
+
+Each JSON object in the `usages` array must be unique the that timestamp,
+resource, and unit tuple. Duplicates will be rejected.
+
+After running the job, you will know if a `Usage` was reported properly if the
+`reported` attribute is set to `true` (defaults to `false`). If it is `false`,
+the `errors` attribute of the `Usage` record should explain why it was not
+reported properly.
+
+*NOTE*: the current implementation does not handle all edge cases at this time.
+If you send invalid data, it is possible for it to silently fail.

--- a/app/jobs/report_usage_job.rb
+++ b/app/jobs/report_usage_job.rb
@@ -1,0 +1,7 @@
+class ReportUsageJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    UsageReporter.new.run
+  end
+end

--- a/app/models/sandwich.rb
+++ b/app/models/sandwich.rb
@@ -1,9 +1,11 @@
-class Sandwich < ActiveRecord::Base
+class Sandwich < ApplicationRecord
   BASE_PLAN = 'test'.freeze
+  USAGE_PLAN = 'usage'.freeze
   PLAN_CONFIG = {
     BASE_PLAN => 'This is a test',
     'pbj' => 'Make me a PB&J!',
     'blt' => 'Make me a BLT!',
+    USAGE_PLAN => 'This is a usage-based plan',
   }.freeze
 
   attribute :oauth_grant_code
@@ -13,6 +15,8 @@ class Sandwich < ActiveRecord::Base
   attr_encrypted :oauth_grant_code, key: ENV['ENCRYPTION_KEY']
   attr_encrypted :access_token, key: ENV['ENCRYPTION_KEY']
   attr_encrypted :refresh_token, key: ENV['ENCRYPTION_KEY']
+
+  has_many :usages
 
   validates :plan, inclusion: { in: PLAN_CONFIG.keys }
 

--- a/app/models/usage.rb
+++ b/app/models/usage.rb
@@ -1,0 +1,4 @@
+class Usage < ApplicationRecord
+  belongs_to :sandwich
+
+end

--- a/app/services/usage_reporter.rb
+++ b/app/services/usage_reporter.rb
@@ -15,7 +15,7 @@ class UsageReporter
       path: "/api/v3/addons/#{slug}/usage_batches",
       headers: {
         'Accept' => 'application/json',
-        'Authorization' => "Basic #{basic_auth_token}",
+        'Authorization' => basic_auth_token,
         'Content-Type' => 'application/json',
       },
       body: JSON.dump(
@@ -26,14 +26,18 @@ class UsageReporter
   end
 
   def mark_usages_as_reported
-    usage_responses.each do |usage_json|
-      usage_record = usage_for(usage_json)
+    if usage_responses
+      usage_responses.each do |usage_json|
+        usage_record = usage_for(usage_json)
 
-      if usage_record && usage_json["status"] == "accepted"
-        usage_record.update!(reported: true)
-      elsif usage_record # rejected
-        usage_record.update!(error_messages: usage_json["errors"])
+        if usage_record && usage_json["status"] == "accepted"
+          usage_record.update!(reported: true)
+        elsif usage_record # rejected
+          usage_record.update!(error_messages: usage_json["errors"])
+        end
       end
+    else
+      puts response.body
     end
   end
 

--- a/app/services/usage_reporter.rb
+++ b/app/services/usage_reporter.rb
@@ -1,0 +1,93 @@
+class UsageReporter
+  BASE_URL = 'https://addons-staging.herokuapp.com'
+
+  def run
+    report_usage_data
+    mark_usages_as_reported
+  end
+
+  private
+
+  attr_reader :response
+
+  def report_usage_data
+    @response ||= Excon.new(BASE_URL).post(
+      path: "/api/v3/addons/#{slug}/usage_batches",
+      headers: {
+        'Accept' => 'application/json',
+        'Authorization' => "Basic #{basic_auth_token}",
+        'Content-Type' => 'application/json',
+      },
+      body: JSON.dump(
+        timestamp: formatted_timestamp,
+        usages: usages_json
+      )
+    )
+  end
+
+  def mark_usages_as_reported
+    usage_responses.each do |usage_json|
+      usage_record = usage_for(usage_json)
+
+      if usage_record && usage_json["status"] == "accepted"
+        usage_record.update!(reported: true)
+      elsif usage_record # rejected
+        usage_record.update!(error_messages: usage_json["errors"])
+      end
+    end
+  end
+
+  def usage_for(usage_json)
+    Usage.
+      joins(:sandwich).
+      where(sandwiches: { heroku_uuid: usage_json["resource"]["id"] }).
+      where(quantity: usage_json["quantity"]).
+      where(unit: usage_json["unit"]["name"]).
+      find_by(timestamp: timestamp)
+  end
+
+  def usage_responses
+    response_body['usages']
+  end
+
+  def timestamp
+    @_timestamp ||= response_body['timestamp']
+  end
+
+  def response_body
+    @_response_body ||= JSON.parse(response.body)
+  end
+
+  def formatted_timestamp
+    (Time.current.beginning_of_hour - 1.hour).
+      strftime("%Y-%m-%dT%H:%M:%SZ")
+  end
+
+  def usages_json
+    usages_for_previous_hour.map do |usage|
+      {
+        quantity: usage.quantity,
+        resource: { id: usage.sandwich.heroku_uuid },
+        unit: { name: usage.unit }
+      }
+    end
+  end
+
+  def usages_for_previous_hour
+    Usage.
+      includes(:sandwich).
+      where("timestamp = ?", 1.hour.ago.beginning_of_hour)
+  end
+
+  def basic_auth_token
+    ActionController::HttpAuthentication::Basic.encode_credentials(slug, password)
+  end
+
+  def slug
+    ENV['SLUG']
+  end
+
+  def password
+    ENV['PASSWORD']
+  end
+end

--- a/db/migrate/20180723214358_create_usages.rb
+++ b/db/migrate/20180723214358_create_usages.rb
@@ -1,0 +1,13 @@
+class CreateUsages < ActiveRecord::Migration[5.1]
+  def change
+    create_table :usages do |t|
+      t.timestamps
+      t.references :sandwich, null: false, index: true
+      t.datetime :timestamp, null: false
+      t.string :unit, null: false
+      t.integer :quantity, null: false
+      t.boolean :reported, default: false
+      t.json :error_messages
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180620163102) do
+ActiveRecord::Schema.define(version: 20180723214358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,18 @@ ActiveRecord::Schema.define(version: 20180620163102) do
     t.datetime "access_token_expires_at"
     t.string "plan"
     t.string "state"
+  end
+
+  create_table "usages", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "sandwich_id", null: false
+    t.datetime "timestamp", null: false
+    t.string "unit", null: false
+    t.integer "quantity", null: false
+    t.boolean "reported", default: false
+    t.json "error_messages"
+    t.index ["sandwich_id"], name: "index_usages_on_sandwich_id"
   end
 
 end

--- a/spec/jobs/report_usage_job_spec.rb
+++ b/spec/jobs/report_usage_job_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe ReportUsageJob do
+  describe '#perform' do
+    it 'calls the usage reporter class' do
+      reporter_double = double(run: true)
+      allow(UsageReporter).to receive(:new).and_return(reporter_double)
+
+      ReportUsageJob.perform_now
+
+      expect(UsageReporter).to have_received(:new)
+      expect(reporter_double).to have_received(:run)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,7 @@ RSpec.configure do |config|
   config.before(:each) do
     WebMock.stub_request(:any, /id.heroku.com/).to_rack(FakeCoreIdentityApi)
     WebMock.stub_request(:any, /api.heroku.com/).to_rack(FakePlatformApi)
+    WebMock.stub_request(:any, /addons-staging.herokuapp.com/).to_rack(FakeAddonsApi)
   end
 
   config.infer_base_class_for_anonymous_controllers = false

--- a/spec/services/usage_reporter_spec.rb
+++ b/spec/services/usage_reporter_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe UsageReporter do
+  describe '#run' do
+    context 'usage data for previous hour is present' do
+      it 'sends usage data and saves errors if any' do
+        datetime = DateTime.new(2018,7,11,4,5,0)
+
+          Timecop.freeze(datetime) do
+          heroku_uuid_from_fixture = 'addon-resource-uuid'
+          errors_from_fixture = ["cannot submit duplicate usages for the same unit, add_on resource, and timestamp"]
+          sandwich = Sandwich.create!(heroku_uuid: heroku_uuid_from_fixture, plan: Sandwich::USAGE_PLAN)
+          accepted_usage = Usage.create!(
+            timestamp: datetime.beginning_of_hour - 1.hour,
+            sandwich: sandwich,
+            unit: 'nibbles',
+            quantity: 5,
+            reported: false,
+          )
+          rejected_usage = Usage.create!(
+            timestamp: datetime.beginning_of_hour - 1.hour,
+            sandwich: sandwich,
+            unit: 'nibbles',
+            quantity: 6,
+            reported: false,
+          )
+
+          described_class.new.run
+
+          expect(accepted_usage.reload).to be_reported
+          expect(rejected_usage.reload).not_to be_reported
+          expect(rejected_usage.error_messages["unit"]).to eq errors_from_fixture
+        end
+      end
+    end
+
+    context 'usage data for previous hour is not present' do
+      it 'does not send usage data' do
+        heroku_uuid = 'some-uuid'
+        sandwich = Sandwich.create!(heroku_uuid: heroku_uuid, plan: Sandwich::USAGE_PLAN)
+        old_usage = Usage.create!(
+          timestamp: 1.day.ago.beginning_of_hour,
+          unit: "whatever",
+          sandwich: sandwich,
+          quantity: 10,
+          reported: false,
+        )
+
+        described_class.new.run
+
+        expect(old_usage.reload).not_to be_reported
+      end
+    end
+  end
+end

--- a/spec/support/fake_addons_api.rb
+++ b/spec/support/fake_addons_api.rb
@@ -1,0 +1,15 @@
+require 'sinatra/base'
+
+class FakeAddonsApi < Sinatra::Base
+  post '/api/v3/addons/:heroku_uuid/usage_batches' do
+    json_response 202, "usage_response.json"
+  end
+
+  private
+
+  def json_response(response_code, file_name)
+    content_type :json
+    status response_code
+    File.open(File.dirname(__FILE__) + '/fixtures/' + file_name, 'rb').read
+  end
+end

--- a/spec/support/fixtures/usage_response.json
+++ b/spec/support/fixtures/usage_response.json
@@ -1,0 +1,21 @@
+{
+  "id": "123-123-123-123",
+  "usages": [
+    {
+      "quantity": 5,
+      "resource": {"id": "addon-resource-uuid"},
+      "unit": {"name": "nibbles"},
+      "id": "some-usage-uuid",
+      "status": "accepted"
+    },
+    {
+      "quantity": 6,
+      "resource": {"id": "addon-resource-uuid"},
+      "unit": {"name": "nibbles"},
+      "id": "some-other-usage-uuid",
+      "status": "rejected",
+      "errors": { "unit": ["cannot submit duplicate usages for the same unit, add_on resource, and timestamp"] }
+    }
+  ],
+  "timestamp": "2018-07-11T03:00:00Z"
+}


### PR DESCRIPTION
This job is enough to show what usage-based reporting looks like.

Some edge cases not covered:
- if we send data for an addon resource that does not exist, we are not
recording the error anywhere
- if the response is a non-202 (400/401/404), we are not recording that fact anywhere.
- if we send duplicate records, we are not able to distinguish the
responses for the duplicates. We are querying on quantity/unit/timestamp
so if we send all of those multiple times we will be getting some
rejected records but right now this sudo-sandwich app does not know how
to deal with those.

TODO: write some instructions on how to set up the data for this to run properly.