### PR TITLE
WIP: Exception in Excon on non-OK status code

### DIFF
--- a/app/services/access_token_refresher.rb
+++ b/app/services/access_token_refresher.rb
@@ -33,7 +33,8 @@ class AccessTokenRefresher
         refresh_token: sandwich.refresh_token,
         grant_type: GRANT_TYPE,
         client_secret: client_secret,
-      }
+      },
+      expects: 200..299
     )
   end
 

--- a/app/services/async_plan_provisioner.rb
+++ b/app/services/async_plan_provisioner.rb
@@ -34,7 +34,8 @@ class AsyncPlanProvisioner
             value: Sandwich::PLAN_CONFIG[sandwich.plan],
           }
         ]
-      )
+      ),
+      expects: 200..299
     )
   end
 
@@ -45,7 +46,8 @@ class AsyncPlanProvisioner
         'Accept' => 'application/vnd.heroku+json; version=3',
         'Authorization' => "Bearer #{access_token}",
         'Content-Type' => 'application/json',
-      }
+      },
+      expects: 200..299
     )
   end
 

--- a/app/services/grant_code_exchanger.rb
+++ b/app/services/grant_code_exchanger.rb
@@ -34,7 +34,8 @@ class GrantCodeExchanger
         code: sandwich.oauth_grant_code,
         grant_type: GRANT_TYPE,
         client_secret: client_secret,
-      }
+      },
+      expects: 200..299
     )
   end
 

--- a/app/services/usage_reporter.rb
+++ b/app/services/usage_reporter.rb
@@ -21,7 +21,8 @@ class UsageReporter
       body: JSON.dump(
         timestamp: formatted_timestamp,
         usages: usages_json
-      )
+      ),
+      expects: 200..299
     )
   end
 


### PR DESCRIPTION
@djcp @jessieay I couldn't find Rollbar exceptions for failures to PATCH config, and it turns out that the Excon wasn't erroring out.

This adds expectations on a success HTTP status code, but it breaks things. I just want to check quick with you (perhaps on a call?) that the tests that are failing are set up with the data and stubs/mocks we'd expect.