### PR TITLE
Fix a typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ After cloning this repo, run: `bin/setup`.
 
 ### Local Server
 
-* Run the server(s): `bin/rails start`
+* Run the server(s): `bin/rails server`
 * Visit [your local server](http://localhost:3000)
 * Run tests: `rake`
 


### PR DESCRIPTION
The README originally instructed the user to type `bin/rails start` to launch the app. It should be `bin/rails server` or `rails server`
Might have been a confusion with `npm start`